### PR TITLE
Crazy4pi314/adding binder support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+    "dockerFile": "../Dockerfile",
+    "remoteEnv": {
+        "IQSHARP_HOSTING_ENV": "QSHARP_BOOK_DEVCONTAINER"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/quantum/iqsharp-base:0.10.1912.0501
+
+ENV IQSHARP_HOSTING_ENV=QSHARP_BOOK_DOCKERFILE
+
+USER root 
+
+# Install additional system packages from apt.
+RUN apt-get -y update && \
+    apt-get -y install \
+        g++ && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
+
+RUN pip install cython \
+                numpy \
+                matplotlib \
+                scipy && \
+    pip install qutip
+
+COPY . ${HOME}
+RUN chown -R ${USER} ${HOME}
+
+USER ${USER}

--- a/ch08/host.ipynb
+++ b/ch08/host.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ch08/host.ipynb
+++ b/ch08/host.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run host.py"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ch09/host.ipynb
+++ b/ch09/host.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/ch09/host.ipynb
+++ b/ch09/host.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run host.py"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR begins adding support for new ways to work with the sample code for the book:
- Docker 
- VS Code [devcontainers](https://code.visualstudio.com/docs/remote/containers)
- [VS Online](https://code.visualstudio.com/docs/remote/vsonline)
- Binder (forthcoming, blocked on microsoft/iqsharp#79)