### PR TITLE
Remove redundant q.reset() calls and unused import

### DIFF
--- a/ch03/bb84.py
+++ b/ch03/bb84.py
@@ -20,7 +20,6 @@ def sample_random_bit(device: QuantumDevice) -> bool:
     with device.using_qubit() as q:
         q.h()
         result = q.measure()
-        q.reset()
     return result
 
 def prepare_message_qubit(message: bool, basis: bool, q: Qubit) -> None:
@@ -114,4 +113,4 @@ if __name__ == "__main__":
 
     decrypted_message = apply_one_time_pad(encrypted_message, key)
     print(f"Eve decrypted to get:             {convert_to_hex(decrypted_message)}.")
-    
+

--- a/ch03/qkd.py
+++ b/ch03/qkd.py
@@ -12,7 +12,6 @@
 ##
 
 from interface import QuantumDevice, Qubit
-from simulator import SingleQubitSimulator
 
 def prepare_classical_message(bit: bool, q: Qubit) -> None:
     if bit:
@@ -25,7 +24,6 @@ def send_classical_bit(device: QuantumDevice, bit: bool) -> None:
     with device.using_qubit() as q:
         prepare_classical_message(bit, q)
         result = eve_measure(q)
-        q.reset()
     assert result == bit
 
 


### PR DESCRIPTION
As per the [`QuantumDevice` interface](https://github.com/crazy4pi314/learn-qc-with-python-and-qsharp/blob/7ffb0119e4f223ff9ab6e2dad0fa381923d2538e/ch03/interface.py#L45), the qubit `reset()` operation already takes place upon exiting from the `using_device` context manager, and this PR proposes removal of a couple of places where an explicit `q.reset()` is called immediately prior to exiting from the `using_device` context manager.

This PR supposes that the proposed-for-removal `q.reset()` lines weren't introduced explicitly with the intention of emphasizing that the operation would take place in a non-simulated context (as I suspect the case _might_ have been [here](https://github.com/crazy4pi314/learn-qc-with-python-and-qsharp/blob/7ffb0119e4f223ff9ab6e2dad0fa381923d2538e/ch03/bb84.py#L36); if not - I would be happy to update this PR and remove that explicit `q.reset()` as well).

Thanks for reviewing this PR!