### PR TITLE
Fix call to gate_expand_1toN in ch05

### DIFF
--- a/ch05/simulator.py
+++ b/ch05/simulator.py
@@ -85,7 +85,7 @@ class Simulator(QuantumDevice):
 
     def _apply(self, unitary: qt.Qobj, ids: List[int]):
         if len(ids) == 1:
-            matrix = qt.circuit.gate_expand_1toN(
+            matrix = gate_expand_1toN(
                 unitary, self.capacity, ids[0]
             )
         else:


### PR DESCRIPTION
A call to gate_expand_1toN was using old namespace, causing it to
fail with latest version of QuTiP (4.7.0). Fixing